### PR TITLE
kubeconfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,6 +45,14 @@
       "args": ["runtime", "mkcert", "--install"]
     },
     {
+      "name": "liferay runtime kubeconfig",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "main.go",
+      "args": ["runtime", "kubeconfig"]
+    },
+    {
       "name": "liferay runtime status",
       "type": "go",
       "request": "launch",

--- a/cmd/ext/build.go
+++ b/cmd/ext/build.go
@@ -7,6 +7,7 @@ package ext
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -44,13 +45,15 @@ var buildCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Build", Done: "is running", On: "'localdev' extension environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-build", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/ext/refresh.go
+++ b/cmd/ext/refresh.go
@@ -7,6 +7,7 @@ package ext
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -41,13 +42,15 @@ var refreshCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Refreshing", Done: "refreshed", On: "'localdev' extension environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-refresh", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/ext/start.go
+++ b/cmd/ext/start.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -103,7 +104,7 @@ var startCmd = &cobra.Command{
 			},
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Starting", Done: "started", On: "'localdev' extension environment", Enable: !flags.Verbose,
 			},
@@ -112,6 +113,8 @@ var startCmd = &cobra.Command{
 			})
 
 		doBrowser()
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/ext/status.go
+++ b/cmd/ext/status.go
@@ -7,6 +7,7 @@ package ext
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -41,13 +42,15 @@ var statusCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Status", Done: "is running", On: "'localdev' extension environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-status", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/ext/stop.go
+++ b/cmd/ext/stop.go
@@ -7,6 +7,7 @@ package ext
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -43,13 +44,15 @@ var stopCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Stopping", Done: "stopped", On: "'localdev' extension environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-down", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/create.go
+++ b/cmd/runtime/create.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -40,13 +41,15 @@ var createCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Creating", Done: "created", On: "'localdev' runtime environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-create", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/delete.go
+++ b/cmd/runtime/delete.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -40,13 +41,15 @@ var deleteCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Deleting", Done: "deleted", On: "'localdev' runtime environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-delete", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/kubeconfig.go
+++ b/cmd/runtime/kubeconfig.go
@@ -47,13 +47,15 @@ var kubeconfigCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Writing", Done: "was written", On: "'kubeconfig' config file", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-kubeconfig", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/kubeconfig.go
+++ b/cmd/runtime/kubeconfig.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+
+*/
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"liferay.com/liferay/cli/constants"
+	"liferay.com/liferay/cli/docker"
+	"liferay.com/liferay/cli/flags"
+	"liferay.com/liferay/cli/spinner"
+)
+
+// kubeconfigCmd represents the kubeconfig command
+var kubeconfigCmd = &cobra.Command{
+	Use:   "kubeconfig",
+	Short: "Generates the kubeconfig necessary to talk to k8s cluster context",
+	Run: func(cmd *cobra.Command, args []string) {
+		userHomeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		config := container.Config{
+			Image: "localdev-server",
+			Cmd:   []string{"/repo/scripts/runtime/kubeconfig.sh"},
+			Env: []string{
+				"LOCALDEV_REPO=/repo",
+				"KUBECONFIG=/var/run/.kube/config",
+			},
+		}
+		host := container.HostConfig{
+			Binds: []string{
+				fmt.Sprintf("%s:%s", viper.GetString(constants.Const.RepoDir), "/repo"),
+				docker.GetDockerSocket() + ":/var/run/docker.sock",
+				filepath.Join(userHomeDir, ".kube") + ":/var/run/.kube",
+			},
+			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
+		}
+
+		spinner.Spin(
+			spinner.SpinOptions{
+				Doing: "Writing", Done: "was written", On: "'kubeconfig' config file", Enable: !flags.Verbose,
+			},
+			func(fior func(io.ReadCloser, bool, string) int) int {
+				return docker.InvokeCommandInLocaldev("localdev-kubeconfig", config, host, true, flags.Verbose, fior, "")
+			})
+	},
+}
+
+func init() {
+	runtimeCmd.AddCommand(kubeconfigCmd)
+}

--- a/cmd/runtime/start.go
+++ b/cmd/runtime/start.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -40,13 +41,15 @@ var startCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Starting", Done: "started", On: "'localdev' runtime environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-start", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/status.go
+++ b/cmd/runtime/status.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -40,13 +41,15 @@ var statusCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Status", Done: "is running", On: "'localdev' runtime environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-status", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/cmd/runtime/stop.go
+++ b/cmd/runtime/stop.go
@@ -7,6 +7,7 @@ package runtime
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/spf13/cobra"
@@ -40,13 +41,15 @@ var stopCmd = &cobra.Command{
 			NetworkMode: container.NetworkMode(viper.GetString(constants.Const.DockerNetwork)),
 		}
 
-		spinner.Spin(
+		exitCode := spinner.Spin(
 			spinner.SpinOptions{
 				Doing: "Stopping", Done: "stopped", On: "'localdev' runtime environment", Enable: !flags.Verbose,
 			},
 			func(fior func(io.ReadCloser, bool, string) int) int {
 				return docker.InvokeCommandInLocaldev("localdev-stop", config, host, true, flags.Verbose, fior, "")
 			})
+
+		os.Exit(exitCode)
 	},
 }
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -224,11 +224,18 @@ func InvokeCommandInLocaldev(
 	}
 
 	if logPipe != nil {
+		pipeChan := make(chan (int))
 		go func() {
 			code := logPipe(out, verbose, exitPattern)
 
-			statusChan <- code
+			pipeChan <- code
 		}()
+
+		pipeCode := <-pipeChan
+
+		if pipeCode < 0 {
+			return 0
+		}
 
 		return <-statusChan
 	}

--- a/spinner/pipe.go
+++ b/spinner/pipe.go
@@ -42,7 +42,7 @@ func SpinnerPipe(s *spinner.Spinner, prefix string) func(io.ReadCloser, bool, st
 					if exitPattern != "" {
 						match, _ := regexp.MatchString(exitPattern, msg)
 						if match {
-							return 0
+							return -1
 						}
 					}
 				}

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -22,7 +22,7 @@ type SpinOptions struct {
 
 type SpinOperation func(func(io.ReadCloser, bool, string) int) int
 
-func Spin(options SpinOptions, operation SpinOperation) {
+func Spin(options SpinOptions, operation SpinOperation) int {
 	var s *spinner.Spinner
 
 	if options.Enable {
@@ -52,4 +52,5 @@ func Spin(options SpinOptions, operation SpinOperation) {
 		s.Stop()
 	}
 
+	return signal
 }


### PR DESCRIPTION
- add `liferay runtime kubeconfig` command to write out .kube/config to communicate to cluster
- return -1 if pipe exits early and return this to spinner if not return from statusChan like usual
- return pipe signal to spinner client
- add debug config
