### PR TITLE
Issue39

### DIFF
--- a/cmd/ext/ext.go
+++ b/cmd/ext/ext.go
@@ -126,17 +126,31 @@ func confirmUseOfDefaultDir() string {
 
 func setClientExtensionDir(dir string) {
 	if !filepath.IsAbs(dir) {
-		dirname, err := os.UserHomeDir()
+		dirname, err := os.Getwd()
+
+		if dir == "." {
+			dir = ""
+		} else if dir[0:2] == "~/" {
+			dirname, err = os.UserHomeDir()
+			dir = dir[2:]
+		} else if dir[0:3] == "~\\" {
+			dirname, err = os.UserHomeDir()
+			dir = dir[3:]
+		}
 
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		dir = filepath.Join(dirname, dir)
+		dir, err = filepath.Abs(filepath.Join(dirname, dir))
+
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	if !io.Exists(dir) {
-		err := os.MkdirAll(dir, 0644)
+		err := os.MkdirAll(dir, 0775)
 
 		if err != nil {
 			log.Fatal(err)
@@ -150,9 +164,9 @@ func setClientExtensionDir(dir string) {
 
 		viper.Set(constants.Const.ExtClientExtensionDir, dir)
 
-		flags.ClientExtensionDir = dir
-
 		viper.Set(constants.Const.ExtClientExtensionDirSpecified, true)
 		viper.WriteConfig()
 	}
+
+	flags.ClientExtensionDir = dir
 }


### PR DESCRIPTION
@gamerson @lawrence-lee Could you see if this matches your expectations:

* specifying a relative path will convert the path to absolute path and if **absent** will create the directory (now with the correct permissions on Mac/Linux), no need to create the directory ahead of time
* **if** the directory is different than the currently recorded directory a message will be printed `Specified Client Extension directory is %s`
* the tilde (`~`) along with the system's path separator (lin/mac = `/`, win = `\\`) may be used as an alias for the path to be relative to the user's home directory. e.g. `-d ~/my-client-extensions` or `-d ~\\my-client-extensions`

A relative path may be of any depth provided that the path separator can be interpreted correctly w.r.t. the file system.